### PR TITLE
parallelToListOrdered() collectors suppliable with custom List implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.pivovarit</groupId>
     <artifactId>parallel-collectors</artifactId>
-    <version>0.1.3-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
@@ -385,6 +385,73 @@ public final class ParallelCollectors {
 
     /**
      * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor}
+     * and returning them as {@link CompletableFuture} containing an ordered {@link List} of these elements
+     *
+     * <br><br>
+     * Original ordering preserved. Instances should not be reused.
+     *
+     * <br><br>
+     * Warning: this implementation can't be used with infinite {@link java.util.stream.Stream} instances.
+     * It will try to submit {@code N} tasks to a provided {@link Executor}
+     * where {@code N} is a size of a collected {@link java.util.stream.Stream}
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * CompletableFuture<List<String>> result = Stream.of(1, 2, 3)
+     *   .collect(parallelToList(i -> foo(), executor));
+     * }</pre>
+     *
+     * @param mapper       a transformation to be performed in parallel
+     * @param listSupplier a {@code Supplier} which returns a mutable {@code List} of the appropriate type
+     * @param executor     the {@code Executor} to use for asynchronous execution
+     * @param <T>          the type of the input elements
+     * @param <R>          the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all input elements into a user-provided mutable {@code List} in parallel
+     *
+     * @since 0.2.0
+     */
+    public static <T, R, C extends List<R>> Collector<T, ?, CompletableFuture<C>> parallelToListOrdered(Function<T, R> mapper, Supplier<C> listSupplier, Executor executor) {
+        requireNonNull(executor, "executor can't be null");
+        requireNonNull(mapper, "mapper can't be null");
+        return new AsyncOrderedParallelCollector<>(mapper, listSupplier, executor);
+    }
+
+    /**
+     * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor}
+     * and returning them as {@link CompletableFuture} containing an ordered {@link List} of these elements
+     *
+     * <br><br>
+     * Original ordering preserved. Instances should not be reused.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * CompletableFuture<List<String>> result = Stream.of(1, 2, 3)
+     *   .collect(parallelToList(i -> foo(), executor, 2));
+     * }</pre>
+     *
+     * @param mapper       a transformation to be performed in parallel
+     * @param listSupplier a {@code Supplier} which returns a mutable {@code List} of the appropriate type
+     * @param executor     the {@code Executor} to use for asynchronous execution
+     * @param parallelism  the parallelism level
+     * @param <T>          the type of the input elements
+     * @param <R>          the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all input elements into a user-provided mutable {@code List} in parallel
+     *
+     * @since 0.2.0
+     */
+    public static <T, R, C extends List<R>> Collector<T, ?, CompletableFuture<C>> parallelToListOrdered(Function<T, R> mapper, Supplier<C> listSupplier, Executor executor, int parallelism) {
+        requireNonNull(executor, "executor can't be null");
+        requireNonNull(mapper, "mapper can't be null");
+        assertParallelismValid(parallelism);
+        return new AsyncOrderedParallelCollector<>(mapper, listSupplier, executor, assertParallelismValid(parallelism));
+    }
+
+    /**
+     * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor}
      * and returning them as {@link CompletableFuture} containing an {@link HashSet} of these element
      *
      * <br><br>

--- a/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
@@ -415,6 +415,7 @@ public final class ParallelCollectors {
     public static <T, R, C extends List<R>> Collector<T, ?, CompletableFuture<C>> parallelToListOrdered(Function<T, R> mapper, Supplier<C> listSupplier, Executor executor) {
         requireNonNull(executor, "executor can't be null");
         requireNonNull(mapper, "mapper can't be null");
+        requireNonNull(listSupplier, "listSupplier can't be null");
         return new AsyncOrderedParallelCollector<>(mapper, listSupplier, executor);
     }
 
@@ -446,6 +447,7 @@ public final class ParallelCollectors {
     public static <T, R, C extends List<R>> Collector<T, ?, CompletableFuture<C>> parallelToListOrdered(Function<T, R> mapper, Supplier<C> listSupplier, Executor executor, int parallelism) {
         requireNonNull(executor, "executor can't be null");
         requireNonNull(mapper, "mapper can't be null");
+        requireNonNull(listSupplier, "listSupplier can't be null");
         assertParallelismValid(parallelism);
         return new AsyncOrderedParallelCollector<>(mapper, listSupplier, executor, assertParallelismValid(parallelism));
     }

--- a/src/test/java/com/pivovarit/collectors/AsyncMappingCollectorFunctionalTest.java
+++ b/src/test/java/com/pivovarit/collectors/AsyncMappingCollectorFunctionalTest.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -56,8 +57,10 @@ class AsyncMappingCollectorFunctionalTest {
           forCollector((mapper, e) -> parallelToList(mapper, e, 1000), "parallelToList(p=1000)"),
           forCollector((mapper, e) -> parallelToListOrdered(mapper, e), "parallelToListOrdered(p=inf)"),
           forCollector((mapper, e) -> parallelToListOrdered(mapper, e, 1000), "parallelToListOrdered(p=1000)"),
-          forCollector((mapper, e) -> parallelToCollection(mapper, ArrayList::new, e), "parallelToCollection(p=inf)"),
-          forCollector((mapper, e) -> parallelToCollection(mapper, ArrayList::new, e, 1000), "parallelToCollection(p=1000)")
+          forCollector((mapper, e) -> parallelToListOrdered(mapper, LinkedList::new, e), "parallelToListOrdered(p=inf)"),
+          forCollector((mapper, e) -> parallelToListOrdered(mapper, LinkedList::new, e, 1000), "parallelToListOrdered(p=1000)"),
+          forCollector((mapper, e) -> parallelToCollection(mapper, LinkedList::new, e), "parallelToCollection(p=inf)"),
+          forCollector((mapper, e) -> parallelToCollection(mapper, LinkedList::new, e, 1000), "parallelToCollection(p=1000)")
         ).flatMap(identity());
     }
 

--- a/src/test/java/com/pivovarit/collectors/infrastructure/TestUtils.java
+++ b/src/test/java/com/pivovarit/collectors/infrastructure/TestUtils.java
@@ -59,6 +59,11 @@ public final class TestUtils {
     }
 
     public static Integer incrementAndThrow(LongAdder counter) {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            // ignore purposefully
+        }
         counter.increment();
         throw new IllegalArgumentException();
     }


### PR DESCRIPTION
Implement parallelToListOrdered() collectors that can be a supplied with a custom List implementation

Related issue: https://github.com/pivovarit/parallel-collectors/issues/196