### PR TITLE
Fix shouldRespectParallelism test

### DIFF
--- a/src/test/java/com/pivovarit/collectors/FunctionalTest.java
+++ b/src/test/java/com/pivovarit/collectors/FunctionalTest.java
@@ -117,7 +117,7 @@ class FunctionalTest {
         return dynamicTest(format("%s: should respect parallelism", name), () -> {
             int parallelism = 2;
             int delayMillis = 50;
-            executor = Executors.newFixedThreadPool(parallelism);
+            executor = Executors.newCachedThreadPool();
 
             LocalTime before = LocalTime.now();
             Stream.generate(() -> 42)


### PR DESCRIPTION
`FunctionalTest#shouldRespectParallelism` would always pass since parallelism was enforced by the size of the thread pool. Reverting to an unbounded one.