### PR TITLE
Optimize for parallelism of one

### DIFF
--- a/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
@@ -6,8 +6,6 @@ import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
 
-import static com.pivovarit.collectors.AsyncParallelCollector.collectingWithCollector;
-
 /**
  * An umbrella class exposing static factory methods for instantiating parallel {@link Collector}s
  *
@@ -43,7 +41,7 @@ public final class ParallelCollectors {
      * @since 2.0.0
      */
     public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor) {
-        return collectingWithCollector(collector, mapper, executor);
+        return AsyncParallelCollector.collectingWithCollector(collector, mapper, executor);
     }
 
     /**
@@ -69,7 +67,9 @@ public final class ParallelCollectors {
      * @since 2.0.0
      */
     public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
-        return collectingWithCollector(collector, mapper, executor, parallelism);
+        return parallelism == 1
+          ? AsyncParallelCollector.Batching.collectingWithCollectorInBatches(collector, mapper, executor, parallelism)
+          : AsyncParallelCollector.collectingWithCollector(collector, mapper, executor, parallelism);
     }
 
     /**
@@ -130,7 +130,9 @@ public final class ParallelCollectors {
      * @since 2.0.0
      */
     public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper, Executor executor, int parallelism) {
-        return AsyncParallelCollector.collectingToStream(mapper, executor, parallelism);
+        return parallelism == 1
+          ? AsyncParallelCollector.Batching.collectingToStreamInBatches(mapper, executor, parallelism)
+          : AsyncParallelCollector.collectingToStream(mapper, executor, parallelism);
     }
 
     /**
@@ -187,7 +189,9 @@ public final class ParallelCollectors {
      * @since 2.0.0
      */
     public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, Executor executor, int parallelism) {
-        return ParallelStreamCollector.streaming(mapper, executor, parallelism);
+        return parallelism == 1
+          ? ParallelStreamCollector.Batching.streamingInBatches(mapper, executor, parallelism)
+          : ParallelStreamCollector.streaming(mapper, executor, parallelism);
     }
 
     /**
@@ -243,7 +247,9 @@ public final class ParallelCollectors {
      * @since 2.0.0
      */
     public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper, Executor executor, int parallelism) {
-        return ParallelStreamCollector.streamingOrdered(mapper, executor, parallelism);
+        return parallelism == 1
+          ? ParallelStreamCollector.Batching.streamingOrderedInBatches(mapper, executor, parallelism)
+          : ParallelStreamCollector.streamingOrdered(mapper, executor, parallelism);
     }
 
     /**

--- a/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
@@ -131,7 +131,10 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
             requireNonNull(mapper, "mapper can't be null");
             requireValidParallelism(parallelism);
 
-            return batched(new ParallelStreamCollector<>(batching(mapper), streamInCompletionOrderStrategy(), UNORDERED, unbounded(executor)), parallelism);
+            return parallelism == 1
+              ? collectingAndThen(toList(), list -> list.stream().map(mapper))
+              : batched(new ParallelStreamCollector<>(
+                batching(mapper), streamInCompletionOrderStrategy(), UNORDERED, unbounded(executor)), parallelism);
         }
 
         static <T, R> Collector<T, ?, Stream<R>> streamingOrderedInBatches(Function<T, R> mapper, Executor executor, int parallelism) {
@@ -139,7 +142,10 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
             requireNonNull(mapper, "mapper can't be null");
             requireValidParallelism(parallelism);
 
-            return batched(new ParallelStreamCollector<>(batching(mapper), streamOrderedStrategy(), emptySet(), unbounded(executor)), parallelism);
+            return parallelism == 1
+              ? collectingAndThen(toList(), list -> list.stream().map(mapper))
+              : batched(new ParallelStreamCollector<>(
+                batching(mapper), streamOrderedStrategy(), emptySet(), unbounded(executor)), parallelism);
         }
 
         private static <T, R> Collector<T, ?, Stream<R>> batched(ParallelStreamCollector<List<T>, List<R>> collector, int parallelism) {

--- a/src/test/java/com/pivovarit/collectors/Bench.java
+++ b/src/test/java/com/pivovarit/collectors/Bench.java
@@ -101,3 +101,24 @@ Bench.parallel_streaming                           10  thrpt    5     94.064 ± 
 Bench.parallel_streaming                          100  thrpt    5    619.749 ±  52.431  ops/s
 Bench.parallel_streaming                         1000  thrpt    5    998.359 ± 116.077  ops/s
  */
+
+
+/*
+Benchmark                               (parallelism)   Mode  Cnt      Score     Error  Units
+Bench.parallel_batch_collect                        1  thrpt    5  10322.716 ± 205.674  ops/s
+Bench.parallel_batch_collect                       10  thrpt    5   8069.709 ± 565.910  ops/s
+Bench.parallel_batch_collect                      100  thrpt    5   2464.723 ± 211.265  ops/s
+Bench.parallel_batch_collect                     1000  thrpt    5   1098.746 ±  62.746  ops/s
+Bench.parallel_batch_streaming_collect              1  thrpt    5  10558.572 ± 149.537  ops/s
+Bench.parallel_batch_streaming_collect             10  thrpt    5   7962.604 ± 193.840  ops/s
+Bench.parallel_batch_streaming_collect            100  thrpt    5   2920.520 ± 250.607  ops/s
+Bench.parallel_batch_streaming_collect           1000  thrpt    5    990.883 ±  85.655  ops/s
+Bench.parallel_collect                              1  thrpt    5  10246.722 ± 233.566  ops/s
+Bench.parallel_collect                             10  thrpt    5    103.467 ±   4.369  ops/s
+Bench.parallel_collect                            100  thrpt    5    738.842 ±  42.034  ops/s
+Bench.parallel_collect                           1000  thrpt    5   1003.320 ± 106.542  ops/s
+Bench.parallel_streaming                            1  thrpt    5  10810.950 ±  79.055  ops/s
+Bench.parallel_streaming                           10  thrpt    5     96.465 ±   4.228  ops/s
+Bench.parallel_streaming                          100  thrpt    5    634.921 ±  39.763  ops/s
+Bench.parallel_streaming                         1000  thrpt    5   1016.447 ± 119.117  ops/s
+ */


### PR DESCRIPTION
https://github.com/pivovarit/parallel-collectors/issues/417

Before:

```
Benchmark                               (parallelism)   Mode  Cnt      Score     Error  Units
Bench.parallel_batch_collect                        1  thrpt    5  10218.766 ± 131.633  ops/s
Bench.parallel_batch_streaming_collect              1  thrpt    5  10715.432 ±  78.383  ops/s
Bench.parallel_collect                              1  thrpt    5     67.891 ±   1.357  ops/s
Bench.parallel_streaming                            1  thrpt    5     50.920 ±   1.569  ops/s
```

After:
```
Benchmark                               (parallelism)   Mode  Cnt      Score     Error  Units
Bench.parallel_batch_collect                        1  thrpt    5  32793.324 ± 898.335  ops/s
Bench.parallel_batch_streaming_collect              1  thrpt    5  69427.286 ± 448.072  ops/s
Bench.parallel_collect                              1  thrpt    5  32163.622 ± 244.584  ops/s
Bench.parallel_streaming                            1  thrpt    5  69148.860 ± 115.817  ops/s
```

@ Intel i7-4980HQ (8) @ 2.80GHz, 8u222