### PR TITLE
Use a calling thread when using blocking streaming instead of creating a new one

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.pivovarit</groupId>
     <artifactId>parallel-collectors</artifactId>
-    <version>2.3.4-SNAPSHOT</version>
+    <version>2.4.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 


### PR DESCRIPTION
Whenever using one of the factories returning `Stream<T>`, the internal dispatcher creates an extra internal thread to orchestrate the processing.

However, this is not necessary since the calling thread could perform the same job. For now, it just blocks and waits for the results.