### PR TITLE
Avoid batching when collection size is equal to parallelism

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.pivovarit</groupId>
     <artifactId>parallel-collectors</artifactId>
-    <version>2.4.2-SNAPSHOT</version>
+    <version>2.5.0-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 


### PR DESCRIPTION
There's no point in batching when each batch would carry only a single element.