### PR TITLE
Dispatcher to use caller thread instead of dedicated scheduler thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ For example:
 
     List<String> result = list.parallelStream()
       .map(i -> foo(i)) // runs implicitly on ForkJoinPool.commonPool()
-      .collect(Collectors.toList());
+      .toList();
 
 In order to avoid such problems, **the solution is to isolate blocking tasks** and run them on a separate thread pool... but there's a catch.
 

--- a/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
+++ b/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
@@ -55,21 +55,12 @@ final class AsyncParallelCollector<T, R, C>
 
     @Override
     public BiConsumer<List<CompletableFuture<R>>, T> accumulator() {
-        return (acc, e) -> {
-            if (!dispatcher.isRunning()) {
-                dispatcher.start();
-            }
-            acc.add(dispatcher.enqueue(() -> mapper.apply(e)));
-        };
+        return (acc, e) -> acc.add(dispatcher.enqueue(() -> mapper.apply(e)));
     }
 
     @Override
     public Function<List<CompletableFuture<R>>, CompletableFuture<C>> finisher() {
-        return futures -> {
-            dispatcher.stop();
-
-            return combine(futures).thenApply(processor);
-        };
+        return futures -> combine(futures).thenApply(processor);
     }
 
     @Override

--- a/src/main/java/com/pivovarit/collectors/Dispatcher.java
+++ b/src/main/java/com/pivovarit/collectors/Dispatcher.java
@@ -1,18 +1,11 @@
 package com.pivovarit.collectors;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 /**
@@ -20,22 +13,12 @@ import java.util.function.Supplier;
  */
 final class Dispatcher<T> {
 
-    private static final Runnable POISON_PILL = () -> System.out.println("Why so serious?");
-
     private final CompletableFuture<Void> completionSignaller = new CompletableFuture<>();
-
-    private final BlockingQueue<Runnable> workingQueue = new LinkedBlockingQueue<>();
-
-    private final ExecutorService dispatcher = newLazySingleThreadExecutor();
     private final Executor executor;
     private final Semaphore limiter;
 
-    private final AtomicBoolean started = new AtomicBoolean(false);
-
-    private volatile boolean shortCircuited = false;
-
     private Dispatcher(int permits) {
-        this.executor = defaultExecutorService();
+        this.executor = Executors.newVirtualThreadPerTaskExecutor();
         this.limiter = new Semaphore(permits);
     }
 
@@ -52,110 +35,65 @@ final class Dispatcher<T> {
         return new Dispatcher<>(permits);
     }
 
-    void start() {
-        if (!started.getAndSet(true)) {
-            dispatcher.execute(() -> {
-                try {
-                    while (true) {
-                        Runnable task;
-                        if ((task = workingQueue.take()) != POISON_PILL) {
-                            executor.execute(() -> {
-                                try {
-                                    limiter.acquire();
-                                    task.run();
-                                } catch (InterruptedException e) {
-                                    handle(e);
-                                } finally {
-                                    limiter.release();
-                                }
-                            });
-                        } else {
-                            break;
-                        }
-                    }
-                } catch (Throwable e) {
-                    handle(e);
-                }
-            });
-        }
-    }
-
-    void stop() {
-        try {
-            workingQueue.put(POISON_PILL);
-        } catch (InterruptedException e) {
-            completionSignaller.completeExceptionally(e);
-        } finally {
-            dispatcher.shutdown();
-        }
-    }
-
-    boolean isRunning() {
-        return started.get();
-    }
-
     CompletableFuture<T> enqueue(Supplier<T> supplier) {
         InterruptibleCompletableFuture<T> future = new InterruptibleCompletableFuture<>();
-        workingQueue.add(completionTask(supplier, future));
-        completionSignaller.exceptionally(shortcircuit(future));
+        completionSignaller.whenComplete(shortcircuit(future));
+        try {
+            executor.execute(completionTask(supplier, future));
+        } catch (Throwable e) {
+            completionSignaller.completeExceptionally(e);
+            return CompletableFuture.failedFuture(e);
+        }
         return future;
     }
 
-    private FutureTask<Void> completionTask(Supplier<T> supplier, InterruptibleCompletableFuture<T> future) {
-        FutureTask<Void> task = new FutureTask<>(() -> {
-            try {
-                if (!shortCircuited) {
-                    future.complete(supplier.get());
+    private FutureTask<T> completionTask(Supplier<T> supplier, InterruptibleCompletableFuture<T> future) {
+        FutureTask<T> task = new FutureTask<>(() -> {
+            if (!completionSignaller.isCompletedExceptionally()) {
+                try {
+                    withLimiter(supplier, future);
+                } catch (Throwable e) {
+                    completionSignaller.completeExceptionally(e);
                 }
-            } catch (Throwable e) {
-                handle(e);
             }
         }, null);
         future.completedBy(task);
         return task;
     }
 
-    private void handle(Throwable e) {
-        shortCircuited = true;
-        completionSignaller.completeExceptionally(e);
-        dispatcher.shutdownNow();
+    private void withLimiter(Supplier<T> supplier, InterruptibleCompletableFuture<T> future) throws InterruptedException {
+        try {
+            limiter.acquire();
+            future.complete(supplier.get());
+        } finally {
+            limiter.release();
+        }
     }
 
-    private static Function<Throwable, Void> shortcircuit(InterruptibleCompletableFuture<?> future) {
-        return throwable -> {
-            future.completeExceptionally(throwable);
-            future.cancel(true);
-            return null;
+    private static <T> BiConsumer<T, Throwable> shortcircuit(InterruptibleCompletableFuture<?> future) {
+        return (__, throwable) -> {
+            if (throwable != null) {
+                future.completeExceptionally(throwable);
+                future.cancel(true);
+            }
         };
-    }
-
-    private static ThreadPoolExecutor newLazySingleThreadExecutor() {
-        return new ThreadPoolExecutor(1, 1,
-          0L, TimeUnit.MILLISECONDS,
-          new SynchronousQueue<>(), // dispatcher always executes a single task
-          Thread.ofPlatform()
-            .name("parallel-collectors-dispatcher-", 0)
-            .daemon(false)
-            .factory());
     }
 
     static final class InterruptibleCompletableFuture<T> extends CompletableFuture<T> {
 
-        private volatile FutureTask<?> backingTask;
-        private void completedBy(FutureTask<Void> task) {
+        private volatile FutureTask<T> backingTask;
+
+        private void completedBy(FutureTask<T> task) {
             backingTask = task;
         }
 
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
-            if (backingTask != null) {
-                backingTask.cancel(mayInterruptIfRunning);
+            var task = backingTask;
+            if (task != null) {
+                task.cancel(mayInterruptIfRunning);
             }
             return super.cancel(mayInterruptIfRunning);
         }
-
-    }
-    private static ExecutorService defaultExecutorService() {
-        return Executors.newVirtualThreadPerTaskExecutor();
     }
 }

--- a/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
@@ -57,10 +57,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
 
     @Override
     public BiConsumer<List<CompletableFuture<R>>, T> accumulator() {
-        return (acc, e) -> {
-            dispatcher.start();
-            acc.add(dispatcher.enqueue(() -> function.apply(e)));
-        };
+        return (acc, e) -> acc.add(dispatcher.enqueue(() -> function.apply(e)));
     }
 
     @Override
@@ -73,10 +70,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
 
     @Override
     public Function<List<CompletableFuture<R>>, Stream<R>> finisher() {
-        return acc -> {
-            dispatcher.stop();
-            return completionStrategy.apply(acc);
-        };
+        return completionStrategy;
     }
 
     @Override

--- a/src/test/java/com/pivovarit/collectors/TestUtils.java
+++ b/src/test/java/com/pivovarit/collectors/TestUtils.java
@@ -11,6 +11,21 @@ public final class TestUtils {
     private TestUtils() {
     }
 
+    public static void withExecutor(Consumer<ExecutorService> consumer) {
+        try (var executorService = Executors.newCachedThreadPool()) {
+            consumer.accept(executorService);
+        }
+    }
+
+    public static <T> T sleepAndReturn(int millis, T value) {
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return value;
+    }
+
     public static <T> T returnWithDelay(T value, Duration duration) {
         try {
             Thread.sleep(duration.toMillis());

--- a/src/test/java/com/pivovarit/collectors/benchmark/Bench.java
+++ b/src/test/java/com/pivovarit/collectors/benchmark/Bench.java
@@ -42,7 +42,7 @@ public class Bench {
 
     private static final List<Integer> source = IntStream.range(0, 1000)
       .boxed()
-      .collect(toList());
+      .toList();
 
     @Benchmark
     public List<Integer> parallel_collect(BenchmarkState state) {
@@ -62,14 +62,14 @@ public class Bench {
     public List<Integer> parallel_streaming(BenchmarkState state) {
         return source.stream()
           .collect(ParallelCollectors.parallelToStream(i -> i, state.executor, state.parallelism))
-          .collect(toList());
+          .toList();
     }
 
     @Benchmark
     public List<Integer> parallel_batch_streaming_collect(BenchmarkState state) {
         return source.stream()
           .collect(ParallelCollectors.Batching.parallelToStream(i -> i, state.executor, state.parallelism))
-          .collect(toList());
+          .toList();
     }
 
     public static void main(String[] args) throws RunnerException {


### PR DESCRIPTION
Remove the internal single-thread scheduler and rely on the caller thread to submit all relevant tasks to a given thread pool. This not only simplified the solution, but also:
- helped avoid context propagation issues when execution switches between multiple threads
- made the tool more Loom-friendly since instances of `ParallelCollectors` do not create their own threads