### PR TITLE
Default to VirtualThreads when Executor not provided

### DIFF
--- a/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
@@ -17,6 +17,32 @@ public final class ParallelCollectors {
     private ParallelCollectors() {
     }
 
+
+    /**
+     * A convenience {@link Collector} used for executing parallel computations using Virtual Threads
+     * and returning them as a {@link CompletableFuture} containing a result of the application of the user-provided {@link Collector}.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * CompletableFuture<List<String>> result = Stream.of(1, 2, 3)
+     *   .collect(parallel(i -> foo(i), toList()));
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param collector   the {@code Collector} describing the reduction
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     * @param <RR>        the reduction result {@code collector}
+     *
+     * @return a {@code Collector} which collects all processed elements into a user-provided mutable {@code Collection} in parallel
+     *
+     * @since 3.0.0
+     */
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector) {
+        return AsyncParallelCollector.collectingWithCollector(collector, mapper);
+    }
+
     /**
      * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor}
      * and returning them as a {@link CompletableFuture} containing a result of the application of the user-provided {@link Collector}.
@@ -42,6 +68,32 @@ public final class ParallelCollectors {
      */
     public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
         return AsyncParallelCollector.collectingWithCollector(collector, mapper, executor, parallelism);
+    }
+
+    /**
+     * A convenience {@link Collector} used for executing parallel computations using Virtual Threads
+     * and returning them as {@link CompletableFuture} containing a {@link Stream} of these elements.
+     *
+     * <br><br>
+     * The collector maintains the order of processed {@link Stream}. Instances should not be reused.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * CompletableFuture<Stream<String>> result = Stream.of(1, 2, 3)
+     *   .collect(parallel(i -> foo()));
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all processed elements into a {@code Stream} in parallel
+     *
+     * @since 3.0.0
+     */
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper) {
+        return AsyncParallelCollector.collectingToStream(mapper);
     }
 
     /**
@@ -73,6 +125,32 @@ public final class ParallelCollectors {
     }
 
     /**
+     * A convenience {@link Collector} used for executing parallel computations using Virtual Threads
+     * and returning a {@link Stream} instance returning results as they arrive.
+     * <p>
+     * For the parallelism of 1, the stream is executed by the calling thread.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * Stream.of(1, 2, 3)
+     *   .collect(parallelToStream(i -> foo()))
+     *   .forEach(System.out::println);
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all processed elements into a {@code Stream} in parallel
+     *
+     * @since 3.0.0
+     */
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper) {
+        return ParallelStreamCollector.streaming(mapper);
+    }
+
+    /**
      * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor}
      * and returning a {@link Stream} instance returning results as they arrive.
      * <p>
@@ -98,6 +176,32 @@ public final class ParallelCollectors {
      */
     public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, Executor executor, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, executor, parallelism);
+    }
+
+    /**
+     * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor}
+     * and returning a {@link Stream} instance returning results as they arrive while maintaining the initial order.
+     * <p>
+     * For the parallelism of 1, the stream is executed by the calling thread.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * Stream.of(1, 2, 3)
+     *   .collect(parallelToOrderedStream(i -> foo()))
+     *   .forEach(System.out::println);
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all processed elements into a {@code Stream} in parallel
+     *
+     * @since 3.0.0
+     */
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper) {
+        return ParallelStreamCollector.streamingOrdered(mapper);
     }
 
     /**

--- a/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
@@ -78,12 +78,24 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
         return characteristics;
     }
 
+    static <T, R> Collector<T, ?, Stream<R>> streaming(Function<T, R> mapper) {
+        requireNonNull(mapper, "mapper can't be null");
+
+        return new ParallelStreamCollector<>(mapper, unordered(), UNORDERED, Dispatcher.virtual());
+    }
+
     static <T, R> Collector<T, ?, Stream<R>> streaming(Function<T, R> mapper, Executor executor, int parallelism) {
         requireNonNull(executor, "executor can't be null");
         requireNonNull(mapper, "mapper can't be null");
         requireValidParallelism(parallelism);
 
         return new ParallelStreamCollector<>(mapper, unordered(), UNORDERED, Dispatcher.from(executor, parallelism));
+    }
+
+    static <T, R> Collector<T, ?, Stream<R>> streamingOrdered(Function<T, R> mapper) {
+        requireNonNull(mapper, "mapper can't be null");
+
+        return new ParallelStreamCollector<>(mapper, ordered(), emptySet(), Dispatcher.virtual());
     }
 
     static <T, R> Collector<T, ?, Stream<R>> streamingOrdered(Function<T, R> mapper, Executor executor,

--- a/src/test/java/com/pivovarit/collectors/CompletionOrderSpliteratorTest.java
+++ b/src/test/java/com/pivovarit/collectors/CompletionOrderSpliteratorTest.java
@@ -1,6 +1,5 @@
 package com.pivovarit.collectors;
 
-import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -11,10 +10,8 @@ import java.util.Spliterator;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static java.time.Duration.ofMillis;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/src/test/java/com/pivovarit/collectors/TestUtils.java
+++ b/src/test/java/com/pivovarit/collectors/TestUtils.java
@@ -4,7 +4,7 @@ import java.time.Duration;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.LongAdder;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 public final class TestUtils {
@@ -36,14 +36,12 @@ public final class TestUtils {
         return value;
     }
 
-    public static Integer incrementAndThrow(LongAdder counter) {
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {
-            // ignore purposefully
+    public static Integer incrementAndThrow(AtomicInteger counter) {
+        if (counter.incrementAndGet() == 10) {
+            throw new IllegalArgumentException();
         }
-        counter.increment();
-        throw new IllegalArgumentException();
+
+        return counter.intValue();
     }
 
     public static void runWithExecutor(Consumer<Executor> consumer, int size) {


### PR DESCRIPTION
Make executor and parallelism parameters optional and default to virtual threads when not provided.