### PR TITLE
Dispatcher to use caller thread instead of dedicated scheduler thread

### DIFF
--- a/src/main/java/com/pivovarit/collectors/Dispatcher.java
+++ b/src/main/java/com/pivovarit/collectors/Dispatcher.java
@@ -1,18 +1,10 @@
 package com.pivovarit.collectors;
 
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.SynchronousQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
+import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import static java.lang.Runtime.getRuntime;
@@ -22,104 +14,61 @@ import static java.lang.Runtime.getRuntime;
  */
 final class Dispatcher<T> {
 
-    private static final Runnable POISON_PILL = () -> System.out.println("Why so serious?");
-
     private final CompletableFuture<Void> completionSignaller = new CompletableFuture<>();
-
-    private final BlockingQueue<Runnable> workingQueue = new LinkedBlockingQueue<>();
-
-    private final ExecutorService dispatcher = newLazySingleThreadExecutor();
     private final Executor executor;
     private final Semaphore limiter;
-
-    private final AtomicBoolean started = new AtomicBoolean(false);
-
-    private volatile boolean shortCircuited = false;
 
     private Dispatcher(Executor executor, int permits) {
         this.executor = executor;
         this.limiter = new Semaphore(permits);
     }
 
-    static <T> Dispatcher<T> of(Executor executor, int permits) {
+    static <T> Dispatcher<T> from(Executor executor, int permits) {
         return new Dispatcher<>(executor, permits);
-    }
-
-    void start() {
-        if (!started.getAndSet(true)) {
-            dispatcher.execute(() -> {
-                try {
-                    while (true) {
-                        Runnable task;
-                        if ((task = workingQueue.take()) != POISON_PILL) {
-                            limiter.acquire();
-                            executor.execute(withFinally(task, limiter::release));
-                        } else {
-                            break;
-                        }
-                    }
-                } catch (Throwable e) {
-                    handle(e);
-                }
-            });
-        }
-    }
-
-    void stop() {
-        try {
-            workingQueue.put(POISON_PILL);
-        } catch (InterruptedException e) {
-            completionSignaller.completeExceptionally(e);
-        } finally {
-            dispatcher.shutdown();
-        }
-    }
-
-    boolean isRunning() {
-        return started.get();
     }
 
     CompletableFuture<T> enqueue(Supplier<T> supplier) {
         InterruptibleCompletableFuture<T> future = new InterruptibleCompletableFuture<>();
-        workingQueue.add(completionTask(supplier, future));
-        completionSignaller.exceptionally(shortcircuit(future));
+        completionSignaller.whenComplete(shortcircuit(future));
+        try {
+            executor.execute(completionTask(supplier, future));
+        } catch (Throwable e) {
+            completionSignaller.completeExceptionally(e);
+            CompletableFuture<T> result = new CompletableFuture<>();
+            result.completeExceptionally(e);
+            return result;
+        }
         return future;
     }
 
-    private FutureTask<Void> completionTask(Supplier<T> supplier, InterruptibleCompletableFuture<T> future) {
-        FutureTask<Void> task = new FutureTask<>(() -> {
-            try {
-                if (!shortCircuited) {
-                    future.complete(supplier.get());
+    private FutureTask<T> completionTask(Supplier<T> supplier, InterruptibleCompletableFuture<T> future) {
+        FutureTask<T> task = new FutureTask<>(() -> {
+            if (!completionSignaller.isCompletedExceptionally()) {
+                try {
+                    withLimiter(supplier, future);
+                } catch (Throwable e) {
+                    completionSignaller.completeExceptionally(e);
                 }
-            } catch (Throwable e) {
-                handle(e);
             }
         }, null);
         future.completedBy(task);
         return task;
     }
 
-    private void handle(Throwable e) {
-        shortCircuited = true;
-        completionSignaller.completeExceptionally(e);
-        dispatcher.shutdownNow();
+    private void withLimiter(Supplier<T> supplier, InterruptibleCompletableFuture<T> future) throws InterruptedException {
+        try {
+            limiter.acquire();
+            future.complete(supplier.get());
+        } finally {
+            limiter.release();
+        }
     }
 
-    private static Function<Throwable, Void> shortcircuit(InterruptibleCompletableFuture<?> future) {
-        return throwable -> {
-            future.completeExceptionally(throwable);
-            future.cancel(true);
-            return null;
-        };
-    }
-
-    private static Runnable withFinally(Runnable task, Runnable finisher) {
-        return () -> {
-            try {
-                task.run();
-            } finally {
-                finisher.run();
+    private static <T> BiConsumer<T, Throwable> shortcircuit(InterruptibleCompletableFuture<?> future) {
+        return (__, throwable) -> {
+            if (throwable != null) {
+                future.completeExceptionally(throwable);
+                future.cancel(true);
             }
         };
     }
@@ -128,29 +77,19 @@ final class Dispatcher<T> {
         return Math.max(getRuntime().availableProcessors() - 1, 4);
     }
 
-    private static ThreadPoolExecutor newLazySingleThreadExecutor() {
-        return new ThreadPoolExecutor(0, 1,
-          0L, TimeUnit.MILLISECONDS,
-          new SynchronousQueue<>(),
-          task -> {
-              Thread thread = Executors.defaultThreadFactory().newThread(task);
-              thread.setName("parallel-collector-" + thread.getName());
-              thread.setDaemon(false);
-              return thread;
-          });
-    }
-
     static final class InterruptibleCompletableFuture<T> extends CompletableFuture<T> {
-        private volatile FutureTask<?> backingTask;
 
-        private void completedBy(FutureTask<Void> task) {
+        private volatile FutureTask<T> backingTask;
+
+        private void completedBy(FutureTask<T> task) {
             backingTask = task;
         }
 
         @Override
         public boolean cancel(boolean mayInterruptIfRunning) {
-            if (backingTask != null) {
-                backingTask.cancel(mayInterruptIfRunning);
+            FutureTask<T> task = backingTask;
+            if (task != null) {
+                task.cancel(mayInterruptIfRunning);
             }
             return super.cancel(mayInterruptIfRunning);
         }


### PR DESCRIPTION
Remove the internal single-thread scheduler and rely on the caller thread to submit all relevant tasks to a given thread pool. This not only simplified the solution, but also:
- helped avoid context propagation issues when execution switches
between multiple threads
- made the tool more Loom-friendly since instances of
`ParallelCollectors` do not create their own threads

----
backport: https://github.com/pivovarit/parallel-collectors/commit/c48c915beeeee8ccd48137b20313668ecf0aa192