### PR TITLE
Replace 'Thread.ofVirtual().start()' with 'Thread.startVirtualThread()'

### DIFF
--- a/src/main/java/com/pivovarit/collectors/Dispatcher.java
+++ b/src/main/java/com/pivovarit/collectors/Dispatcher.java
@@ -61,7 +61,7 @@ final class Dispatcher<T> {
 
     void start() {
         if (!started.getAndSet(true)) {
-            Thread.ofVirtual().start(() -> {
+            Thread.startVirtualThread(() -> {
                 try {
                     while (true) {
                         try {


### PR DESCRIPTION
There's no need for using the builder when all we need is to simply start a `Thread`