### PR TITLE
Add new API methods supporting custom Executors with unbounded parallelism

### DIFF
--- a/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
+++ b/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
@@ -106,6 +106,13 @@ final class AsyncParallelCollector<T, R, C>
         return new AsyncParallelCollector<>(mapper, Dispatcher.virtual(parallelism), Function.identity());
     }
 
+    static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> collectingToStream(Function<T, R> mapper, Executor executor) {
+        requireNonNull(executor, "executor can't be null");
+        requireNonNull(mapper, "mapper can't be null");
+
+        return new AsyncParallelCollector<>(mapper, Dispatcher.from(executor), Function.identity());
+    }
+
     static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> collectingToStream(Function<T, R> mapper, Executor executor, int parallelism) {
         requireNonNull(executor, "executor can't be null");
         requireNonNull(mapper, "mapper can't be null");
@@ -131,6 +138,14 @@ final class AsyncParallelCollector<T, R, C>
         return parallelism == 1
           ? asyncCollector(mapper, Executors.newVirtualThreadPerTaskExecutor(), s -> s.collect(collector))
           : new AsyncParallelCollector<>(mapper, Dispatcher.virtual(parallelism), s -> s.collect(collector));
+    }
+
+    static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> collectingWithCollector(Collector<R, ?, RR> collector, Function<T, R> mapper, Executor executor) {
+        requireNonNull(collector, "collector can't be null");
+        requireNonNull(executor, "executor can't be null");
+        requireNonNull(mapper, "mapper can't be null");
+
+        return new AsyncParallelCollector<>(mapper, Dispatcher.from(executor), s -> s.collect(collector));
     }
 
     static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> collectingWithCollector(Collector<R, ?, RR> collector, Function<T, R> mapper, Executor executor, int parallelism) {

--- a/src/main/java/com/pivovarit/collectors/Dispatcher.java
+++ b/src/main/java/com/pivovarit/collectors/Dispatcher.java
@@ -47,6 +47,15 @@ final class Dispatcher<T> {
         this.limiter = new Semaphore(permits);
     }
 
+    private Dispatcher(Executor executor) {
+        this.executor = executor;
+        this.limiter = null;
+    }
+
+    static <T> Dispatcher<T> from(Executor executor) {
+        return new Dispatcher<>(executor);
+    }
+
     static <T> Dispatcher<T> from(Executor executor, int permits) {
         return new Dispatcher<>(executor, permits);
     }

--- a/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
@@ -96,6 +96,32 @@ public final class ParallelCollectors {
     }
 
     /**
+     * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor} with unlimited parallelism
+     * and returning them as a {@link CompletableFuture} containing a result of the application of the user-provided {@link Collector}.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * CompletableFuture<List<String>> result = Stream.of(1, 2, 3)
+     *   .collect(parallel(i -> foo(i), toList(), executor));
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param collector   the {@code Collector} describing the reduction
+     * @param executor    the {@code Executor} to use for asynchronous execution
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     * @param <RR>        the reduction result {@code collector}
+     *
+     * @return a {@code Collector} which collects all processed elements into a user-provided mutable {@code Collection} in parallel
+     *
+     * @since 3.3.0
+     */
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor) {
+        return AsyncParallelCollector.collectingWithCollector(collector, mapper, executor);
+    }
+
+    /**
      * A convenience {@link Collector} used for executing parallel computations using Virtual Threads
      * and returning them as {@link CompletableFuture} containing a {@link Stream} of these elements.
      *
@@ -176,6 +202,33 @@ public final class ParallelCollectors {
     }
 
     /**
+     * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor} with unlimited parallelism
+     * and returning them as {@link CompletableFuture} containing a {@link Stream} of these elements.
+     *
+     * <br><br>
+     * The collector maintains the order of processed {@link Stream}. Instances should not be reused.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * CompletableFuture<Stream<String>> result = Stream.of(1, 2, 3)
+     *   .collect(parallel(i -> foo(), executor));
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param executor    the {@code Executor} to use for asynchronous execution
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all processed elements into a {@code Stream} in parallel
+     *
+     * @since 3.3.0
+     */
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper, Executor executor) {
+        return AsyncParallelCollector.collectingToStream(mapper, executor);
+    }
+
+    /**
      * A convenience {@link Collector} used for executing parallel computations using Virtual Threads
      * and returning a {@link Stream} instance returning results as they arrive.
      * <p>
@@ -226,6 +279,33 @@ public final class ParallelCollectors {
      */
     public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, parallelism);
+    }
+
+    /**
+     * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor} with unlimited parallelism
+     * and returning a {@link Stream} instance returning results as they arrive.
+     * <p>
+     * For the parallelism of 1, the stream is executed by the calling thread.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * Stream.of(1, 2, 3)
+     *   .collect(parallelToStream(i -> foo(), executor, 2))
+     *   .forEach(System.out::println);
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param executor    the {@code Executor} to use for asynchronous execution
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all processed elements into a {@code Stream} in parallel
+     *
+     * @since 3.3.0
+     */
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, Executor executor) {
+        return ParallelStreamCollector.streaming(mapper, executor);
     }
 
     /**
@@ -307,6 +387,33 @@ public final class ParallelCollectors {
      */
     public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper, int parallelism) {
         return ParallelStreamCollector.streamingOrdered(mapper, parallelism);
+    }
+
+    /**
+     * A convenience {@link Collector} used for executing parallel computations on a custom {@link Executor} with unlimited parallelism
+     * and returning a {@link Stream} instance returning results as they arrive while maintaining the initial order.
+     * <p>
+     * For the parallelism of 1, the stream is executed by the calling thread.
+     *
+     * <br>
+     * Example:
+     * <pre>{@code
+     * Stream.of(1, 2, 3)
+     *   .collect(parallelToOrderedStream(i -> foo(), executor))
+     *   .forEach(System.out::println);
+     * }</pre>
+     *
+     * @param mapper      a transformation to be performed in parallel
+     * @param executor    the {@code Executor} to use for asynchronous execution
+     * @param <T>         the type of the collected elements
+     * @param <R>         the result returned by {@code mapper}
+     *
+     * @return a {@code Collector} which collects all processed elements into a {@code Stream} in parallel
+     *
+     * @since 3.3.0
+     */
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper, Executor executor) {
+        return ParallelStreamCollector.streamingOrdered(mapper, executor);
     }
 
     /**

--- a/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
@@ -97,6 +97,13 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
         return new ParallelStreamCollector<>(mapper, unordered(), UNORDERED, Dispatcher.virtual(parallelism));
     }
 
+    static <T, R> Collector<T, ?, Stream<R>> streaming(Function<T, R> mapper, Executor executor) {
+        requireNonNull(executor, "executor can't be null");
+        requireNonNull(mapper, "mapper can't be null");
+
+        return new ParallelStreamCollector<>(mapper, unordered(), UNORDERED, Dispatcher.from(executor));
+    }
+
     static <T, R> Collector<T, ?, Stream<R>> streaming(Function<T, R> mapper, Executor executor, int parallelism) {
         requireNonNull(executor, "executor can't be null");
         requireNonNull(mapper, "mapper can't be null");
@@ -116,6 +123,13 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
         requireValidParallelism(parallelism);
 
         return new ParallelStreamCollector<>(mapper, ordered(), emptySet(), Dispatcher.virtual(parallelism));
+    }
+
+    static <T, R> Collector<T, ?, Stream<R>> streamingOrdered(Function<T, R> mapper, Executor executor) {
+        requireNonNull(executor, "executor can't be null");
+        requireNonNull(mapper, "mapper can't be null");
+
+        return new ParallelStreamCollector<>(mapper, ordered(), emptySet(), Dispatcher.from(executor));
     }
 
     static <T, R> Collector<T, ?, Stream<R>> streamingOrdered(Function<T, R> mapper, Executor executor,


### PR DESCRIPTION
Add new API methods that accept a custom `Executor` but allow unlimited parallelism without extra overhead:

```
Collector<...> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor)
Collector<...> parallel(Function<T, R> mapper, Executor executor) 
Collector<...> parallelToStream(Function<T, R> mapper, Executor executor)
Collector<...> parallelToOrderedStream(Function<T, R> mapper, Executor executor)
```

resolves: https://github.com/pivovarit/parallel-collectors/issues/918