### PR TITLE
Use Function<? super T, ? extends R> to maximize variance support

### DIFF
--- a/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
+++ b/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
@@ -30,11 +30,11 @@ final class AsyncParallelCollector<T, R, C>
   implements Collector<T, List<CompletableFuture<R>>, CompletableFuture<C>> {
 
     private final Dispatcher<R> dispatcher;
-    private final Function<T, R> task;
+    private final Function<? super T, R> task;
     private final Function<Stream<R>, C> finalizer;
 
     private AsyncParallelCollector(
-      Function<T, R> task,
+      Function<? super T, R> task,
       Dispatcher<R> dispatcher,
       Function<Stream<R>, C> finalizer) {
         this.dispatcher = dispatcher;
@@ -93,7 +93,7 @@ final class AsyncParallelCollector<T, R, C>
         return combined;
     }
 
-    static <T, R, C> Collector<T, ?, CompletableFuture<C>> collecting(Function<Stream<R>, C> finalizer, Function<T, R> mapper, Option... options) {
+    static <T, R, C> Collector<T, ?, CompletableFuture<C>> collecting(Function<Stream<R>, C> finalizer, Function<? super T, R> mapper, Option... options) {
         requireNonNull(mapper, "mapper can't be null");
 
         Option.Configuration config = Option.process(options);
@@ -135,7 +135,7 @@ final class AsyncParallelCollector<T, R, C>
         }
     }
 
-    static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> asyncCollector(Function<T, R> mapper, Executor executor, Function<Stream<R>, RR> finisher) {
+    static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> asyncCollector(Function<? super T, R> mapper, Executor executor, Function<Stream<R>, RR> finisher) {
         return collectingAndThen(toList(), list -> {
             try {
                 return supplyAsync(() -> {
@@ -151,11 +151,11 @@ final class AsyncParallelCollector<T, R, C>
         });
     }
 
-    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<T, R> mapper, int parallelism, Function<Stream<R>, RR> finisher) {
+    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<? super T, R> mapper, int parallelism, Function<Stream<R>, RR> finisher) {
         return batchingCollector(mapper, null, parallelism, finisher);
     }
 
-    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<T, R> mapper, Executor executor, int parallelism, Function<Stream<R>, RR> finisher) {
+    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<? super T, R> mapper, Executor executor, int parallelism, Function<Stream<R>, RR> finisher) {
         return collectingAndThen(
           toList(),
           list -> {

--- a/src/main/java/com/pivovarit/collectors/BatchingSpliterator.java
+++ b/src/main/java/com/pivovarit/collectors/BatchingSpliterator.java
@@ -55,7 +55,7 @@ final class BatchingSpliterator<T> implements Spliterator<List<T>> {
         return acc.build();
     }
 
-    static <T, R> Function<List<T>, List<R>> batching(Function<T, R> mapper) {
+    static <T, R> Function<List<T>, List<R>> batching(Function<? super T, R> mapper) {
         return batch -> {
             List<R> list = new ArrayList<>(batch.size());
             for (T t : batch) {

--- a/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
@@ -42,7 +42,7 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper);
     }
 
@@ -68,7 +68,7 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, int parallelism) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, int parallelism) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper, parallelism(parallelism));
     }
 
@@ -95,7 +95,7 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper, executor(executor), parallelism(parallelism));
     }
 
@@ -121,7 +121,7 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, Executor executor) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper, executor(executor));
     }
 
@@ -147,7 +147,7 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper) {
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper) {
         return AsyncParallelCollector.collecting(i -> i, mapper);
     }
 
@@ -174,7 +174,7 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper, int parallelism) {
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, int parallelism) {
         return AsyncParallelCollector.collecting(i -> i, mapper, parallelism(parallelism));
     }
 
@@ -202,7 +202,7 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper, Executor executor, int parallelism) {
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, Executor executor, int parallelism) {
         return AsyncParallelCollector.collecting(i -> i, mapper, executor(executor), parallelism(parallelism));
     }
 
@@ -229,7 +229,7 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper, Executor executor) {
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, Executor executor) {
         return AsyncParallelCollector.collecting(i -> i, mapper, executor(executor));
     }
 
@@ -255,7 +255,7 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper) {
         return ParallelStreamCollector.streaming(mapper, false);
     }
 
@@ -282,7 +282,7 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, false, parallelism(parallelism));
     }
 
@@ -309,7 +309,7 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, Executor executor) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, Executor executor) {
         return ParallelStreamCollector.streaming(mapper, false, executor(executor));
     }
 
@@ -337,7 +337,7 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, Executor executor, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, false, executor(executor), parallelism(parallelism));
     }
 
@@ -363,7 +363,7 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper) {
         return ParallelStreamCollector.streaming(mapper, true);
     }
 
@@ -390,7 +390,7 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, true, parallelism(parallelism));
     }
 
@@ -417,7 +417,7 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper, Executor executor) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, Executor executor) {
         return ParallelStreamCollector.streaming(mapper, true, executor(executor));
     }
 
@@ -445,7 +445,7 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper, Executor executor, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, true, executor(executor), parallelism(parallelism));
     }
 
@@ -511,7 +511,7 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
+        public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
             return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper,
               batched(),
               executor(executor),
@@ -542,7 +542,7 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<T, R> mapper, Executor executor, int parallelism) {
+        public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, Executor executor, int parallelism) {
             return AsyncParallelCollector.collecting(s -> s, mapper,
               batched(),
               executor(executor),
@@ -573,7 +573,7 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<T, R> mapper, Executor executor, int parallelism) {
+        public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
             return ParallelStreamCollector.streaming(mapper, false,
               batched(),
               executor(executor),
@@ -604,7 +604,7 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<T, R> mapper, Executor executor, int parallelism) {
+        public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
             return ParallelStreamCollector.streaming(mapper, true,
               batched(),
               executor(executor),

--- a/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
@@ -30,7 +30,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
 
     private static final EnumSet<Characteristics> UNORDERED = EnumSet.of(Characteristics.UNORDERED);
 
-    private final Function<T, R> function;
+    private final Function<? super T, R> function;
 
     private final CompletionStrategy<R> completionStrategy;
 
@@ -39,7 +39,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
     private final Dispatcher<R> dispatcher;
 
     private ParallelStreamCollector(
-      Function<T, R> function,
+      Function<? super T, R> function,
       CompletionStrategy<R> completionStrategy,
       Set<Characteristics> characteristics,
       Dispatcher<R> dispatcher) {
@@ -83,7 +83,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
         return characteristics;
     }
 
-    static <T, R> Collector<T, ?, Stream<R>> streaming(Function<T, R> mapper, boolean ordered, Option... options) {
+    static <T, R> Collector<T, ?, Stream<R>> streaming(Function<? super T, R> mapper, boolean ordered, Option... options) {
         requireNonNull(mapper, "mapper can't be null");
 
         Option.Configuration config = Option.process(options);
@@ -127,7 +127,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
         }
     }
 
-    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<T, R> mapper, Executor executor, int parallelism) {
+    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<? super T, R> mapper, Executor executor, int parallelism) {
         return collectingAndThen(
           toList(),
           list -> {
@@ -155,11 +155,11 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
           });
     }
 
-    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<T, R> mapper, int parallelism) {
+    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<? super T, R> mapper, int parallelism) {
         return batchingCollector(mapper, null, parallelism);
     }
 
-    static <T, R> Collector<T, Stream.Builder<R>, Stream<R>> syncCollector(Function<T, R> mapper) {
+    static <T, R> Collector<T, Stream.Builder<R>, Stream<R>> syncCollector(Function<? super T, R> mapper) {
         return Collector.of(Stream::builder, (rs, t) -> rs.add(mapper.apply(t)), (rs, rs2) -> {
             throw new UnsupportedOperationException("Using parallel stream with parallel collectors is a bad idea");
         }, Stream.Builder::build);

--- a/src/test/java/com/pivovarit/collectors/TypeBoundsTest.java
+++ b/src/test/java/com/pivovarit/collectors/TypeBoundsTest.java
@@ -1,0 +1,82 @@
+package com.pivovarit.collectors;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static java.util.stream.Collectors.toList;
+
+class TypeBoundsTest {
+
+    private final Function<Integer, String> its = i -> i.toString();
+    private final Function<Object, String> ots = i -> i.toString();
+
+    @Test
+    void shouldCompileBatchingParallel() {
+        Collector<Integer, ?, CompletableFuture<Stream<String>>> collector;
+        collector = ParallelCollectors.Batching.parallel(its, r -> {}, 42);
+        collector = ParallelCollectors.Batching.parallel(ots, r -> {}, 42);
+    }
+
+    @Test
+    void shouldCompileBatchingParallelToList() {
+        Collector<Integer, ?, CompletableFuture<List<String>>> collector;
+        collector = ParallelCollectors.Batching.parallel(its, toList(), r -> {}, 42);
+        collector = ParallelCollectors.Batching.parallel(ots, toList(), r -> {}, 42);
+    }
+
+    @Test
+    void shouldCompileBatchingStreaming() {
+        Collector<Integer, ?, Stream<String>> collector;
+        collector = ParallelCollectors.Batching.parallelToStream(its, r -> {}, 42);
+        collector = ParallelCollectors.Batching.parallelToStream(ots, r -> {}, 42);
+
+        collector = ParallelCollectors.Batching.parallelToOrderedStream(its, r -> {}, 42);
+        collector = ParallelCollectors.Batching.parallelToOrderedStream(ots, r -> {}, 42);
+    }
+
+    @Test
+    void shouldCompileParallel() {
+        Collector<Integer, ?, CompletableFuture<Stream<String>>> collector;
+        collector = ParallelCollectors.parallel(its, r -> {}, 42);
+        collector = ParallelCollectors.parallel(ots, r -> {}, 42);
+
+        collector = ParallelCollectors.parallel(its, r -> {});
+        collector = ParallelCollectors.parallel(ots, r -> {});
+
+        collector = ParallelCollectors.parallel(its);
+        collector = ParallelCollectors.parallel(ots);
+    }
+
+    @Test
+    void shouldCompileParallelToList() {
+        Collector<Integer, ?, CompletableFuture<List<String>>> collector;
+        collector = ParallelCollectors.parallel(its, toList(), r -> {}, 42);
+        collector = ParallelCollectors.parallel(ots, toList(), r -> {}, 42);
+
+        collector = ParallelCollectors.parallel(its, toList(), r -> {});
+        collector = ParallelCollectors.parallel(ots, toList(), r -> {});
+
+        collector = ParallelCollectors.parallel(its, toList());
+        collector = ParallelCollectors.parallel(ots, toList());
+    }
+
+    @Test
+    void shouldCompileStreaming() {
+        Collector<Integer, ?, Stream<String>> collector;
+        collector = ParallelCollectors.parallelToStream(its, r -> {}, 42);
+        collector = ParallelCollectors.parallelToStream(ots, r -> {}, 42);
+
+        collector = ParallelCollectors.parallelToStream(its, r -> {});
+        collector = ParallelCollectors.parallelToStream(ots, r -> {});
+
+        collector = ParallelCollectors.parallelToOrderedStream(its, r -> {}, 42);
+        collector = ParallelCollectors.parallelToOrderedStream(ots, r -> {}, 42);
+
+        collector = ParallelCollectors.parallelToOrderedStream(its, r -> {});
+        collector = ParallelCollectors.parallelToOrderedStream(ots, r -> {});
+    }
+}


### PR DESCRIPTION
Let's say we have a `Collector` accepting `Integer` elements and returning a `Stream<String>`.

This can be achieved by passing `Function<Integer, String>`, but it would be perfectly valid to pass `Function<Object, String>` as well, but it's not possible at the moment:

```java
Function<Integer, String> f1 = i -> i.toString();
Function<Object, String> f2 = i -> i.toString();

Collector<Integer, ?, CompletableFuture<Stream<String>>> e1 = parallel((Integer i) -> i.toString());
// Incompatible equality constraint: Integer and Object
Collector<Integer, ?, CompletableFuture<Stream<String>>> e2 = parallel((Object i) -> i.toString());
```

This change loosens generic type bounds to maximize variance support, making this possible.
