### PR TITLE
Use Function<? super T, ? extends R> to maximize variance support (covariance)

### DIFF
--- a/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
+++ b/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
@@ -29,11 +29,11 @@ final class AsyncParallelCollector<T, R, C>
   implements Collector<T, List<CompletableFuture<R>>, CompletableFuture<C>> {
 
     private final Dispatcher<R> dispatcher;
-    private final Function<? super T, R> task;
+    private final Function<? super T, ? extends R> task;
     private final Function<Stream<R>, C> finalizer;
 
     private AsyncParallelCollector(
-      Function<? super T, R> task,
+      Function<? super T, ? extends R> task,
       Dispatcher<R> dispatcher,
       Function<Stream<R>, C> finalizer) {
         this.dispatcher = dispatcher;
@@ -92,7 +92,12 @@ final class AsyncParallelCollector<T, R, C>
         return combined;
     }
 
-    static <T, R, C> Collector<T, ?, CompletableFuture<C>> collecting(Function<Stream<R>, C> finalizer, Function<? super T, R> mapper, Option... options) {
+    static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> collecting(Function<? super T, ? extends R> mapper, Option... options) {
+        Function<Stream<R>, Stream<R>> finalizer = i -> i;
+        return collecting(finalizer, mapper, options);
+    }
+
+    static <T, R, C> Collector<T, ?, CompletableFuture<C>> collecting(Function<Stream<R>, C> finalizer, Function<? super T, ? extends R> mapper, Option... options) {
         requireNonNull(mapper, "mapper can't be null");
 
         Option.Configuration config = Option.process(options);
@@ -134,11 +139,11 @@ final class AsyncParallelCollector<T, R, C>
         }
     }
 
-    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<? super T, R> mapper, int parallelism, Function<Stream<R>, RR> finisher) {
+    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<? super T, ? extends R> mapper, int parallelism, Function<Stream<R>, RR> finisher) {
         return batchingCollector(mapper, null, parallelism, finisher);
     }
 
-    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<? super T, R> mapper, Executor executor, int parallelism, Function<Stream<R>, RR> finisher) {
+    private static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> batchingCollector(Function<? super T, ? extends R> mapper, Executor executor, int parallelism, Function<Stream<R>, RR> finisher) {
         return collectingAndThen(
           toList(),
           list -> {
@@ -165,12 +170,12 @@ final class AsyncParallelCollector<T, R, C>
 
     private static class AsyncCollector<T, R, RR> implements Collector<T, Stream.Builder<T>, CompletableFuture<RR>> {
 
-        private final Function<? super T, R> mapper;
+        private final Function<? super T, ? extends R> mapper;
         private final Function<Stream<R>, RR> finisher;
 
         private final Executor executor;
 
-        AsyncCollector(Function<? super T, R> mapper, Function<Stream<R>, RR> finisher, Executor executor) {
+        AsyncCollector(Function<? super T, ? extends R> mapper, Function<Stream<R>, RR> finisher, Executor executor) {
             this.mapper = mapper;
             this.finisher = finisher;
             this.executor = executor;

--- a/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelCollectors.java
@@ -42,7 +42,7 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, ? extends R> mapper, Collector<R, ?, RR> collector) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper);
     }
 
@@ -68,7 +68,7 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, int parallelism) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, ? extends R> mapper, Collector<R, ?, RR> collector, int parallelism) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper, parallelism(parallelism));
     }
 
@@ -95,7 +95,7 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, ? extends R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper, executor(executor), parallelism(parallelism));
     }
 
@@ -121,7 +121,7 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, Executor executor) {
+    public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, ? extends R> mapper, Collector<R, ?, RR> collector, Executor executor) {
         return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper, executor(executor));
     }
 
@@ -147,8 +147,8 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper) {
-        return AsyncParallelCollector.collecting(i -> i, mapper);
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, ? extends R> mapper) {
+        return AsyncParallelCollector.collecting(mapper);
     }
 
     /**
@@ -174,8 +174,8 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, int parallelism) {
-        return AsyncParallelCollector.collecting(i -> i, mapper, parallelism(parallelism));
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, ? extends R> mapper, int parallelism) {
+        return AsyncParallelCollector.collecting(mapper, parallelism(parallelism));
     }
 
     /**
@@ -202,8 +202,8 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, Executor executor, int parallelism) {
-        return AsyncParallelCollector.collecting(i -> i, mapper, executor(executor), parallelism(parallelism));
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, ? extends R> mapper, Executor executor, int parallelism) {
+        return AsyncParallelCollector.collecting(mapper, executor(executor), parallelism(parallelism));
     }
 
     /**
@@ -229,8 +229,8 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, Executor executor) {
-        return AsyncParallelCollector.collecting(i -> i, mapper, executor(executor));
+    public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, ? extends R> mapper, Executor executor) {
+        return AsyncParallelCollector.collecting(mapper, executor(executor));
     }
 
     /**
@@ -255,7 +255,7 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, ? extends R> mapper) {
         return ParallelStreamCollector.streaming(mapper, false);
     }
 
@@ -282,7 +282,7 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, ? extends R> mapper, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, false, parallelism(parallelism));
     }
 
@@ -309,7 +309,7 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, Executor executor) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, ? extends R> mapper, Executor executor) {
         return ParallelStreamCollector.streaming(mapper, false, executor(executor));
     }
 
@@ -337,7 +337,7 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, ? extends R> mapper, Executor executor, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, false, executor(executor), parallelism(parallelism));
     }
 
@@ -363,7 +363,7 @@ public final class ParallelCollectors {
      *
      * @since 3.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, ? extends R> mapper) {
         return ParallelStreamCollector.streaming(mapper, true);
     }
 
@@ -390,7 +390,7 @@ public final class ParallelCollectors {
      *
      * @since 3.2.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, ? extends R> mapper, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, true, parallelism(parallelism));
     }
 
@@ -417,7 +417,7 @@ public final class ParallelCollectors {
      *
      * @since 3.3.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, Executor executor) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, ? extends R> mapper, Executor executor) {
         return ParallelStreamCollector.streaming(mapper, true, executor(executor));
     }
 
@@ -445,7 +445,7 @@ public final class ParallelCollectors {
      *
      * @since 2.0.0
      */
-    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
+    public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, ? extends R> mapper, Executor executor, int parallelism) {
         return ParallelStreamCollector.streaming(mapper, true, executor(executor), parallelism(parallelism));
     }
 
@@ -511,7 +511,7 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
+        public static <T, R, RR> Collector<T, ?, CompletableFuture<RR>> parallel(Function<? super T, ? extends R> mapper, Collector<R, ?, RR> collector, Executor executor, int parallelism) {
             return AsyncParallelCollector.collecting(s -> s.collect(collector), mapper,
               batched(),
               executor(executor),
@@ -542,8 +542,8 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, R> mapper, Executor executor, int parallelism) {
-            return AsyncParallelCollector.collecting(s -> s, mapper,
+        public static <T, R> Collector<T, ?, CompletableFuture<Stream<R>>> parallel(Function<? super T, ? extends R> mapper, Executor executor, int parallelism) {
+            return AsyncParallelCollector.collecting(mapper,
               batched(),
               executor(executor),
               parallelism(parallelism));
@@ -573,7 +573,7 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
+        public static <T, R> Collector<T, ?, Stream<R>> parallelToStream(Function<? super T, ? extends R> mapper, Executor executor, int parallelism) {
             return ParallelStreamCollector.streaming(mapper, false,
               batched(),
               executor(executor),
@@ -604,7 +604,7 @@ public final class ParallelCollectors {
          *
          * @since 2.1.0
          */
-        public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, R> mapper, Executor executor, int parallelism) {
+        public static <T, R> Collector<T, ?, Stream<R>> parallelToOrderedStream(Function<? super T, ? extends R> mapper, Executor executor, int parallelism) {
             return ParallelStreamCollector.streaming(mapper, true,
               batched(),
               executor(executor),

--- a/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
+++ b/src/main/java/com/pivovarit/collectors/ParallelStreamCollector.java
@@ -30,7 +30,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
 
     private static final EnumSet<Characteristics> UNORDERED = EnumSet.of(Characteristics.UNORDERED);
 
-    private final Function<? super T, R> function;
+    private final Function<? super T, ? extends R> function;
 
     private final CompletionStrategy<R> completionStrategy;
 
@@ -39,7 +39,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
     private final Dispatcher<R> dispatcher;
 
     private ParallelStreamCollector(
-      Function<? super T, R> function,
+      Function<? super T, ? extends R> function,
       CompletionStrategy<R> completionStrategy,
       Set<Characteristics> characteristics,
       Dispatcher<R> dispatcher) {
@@ -83,7 +83,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
         return characteristics;
     }
 
-    static <T, R> Collector<T, ?, Stream<R>> streaming(Function<? super T, R> mapper, boolean ordered, Option... options) {
+    static <T, R> Collector<T, ?, Stream<R>> streaming(Function<? super T, ? extends R> mapper, boolean ordered, Option... options) {
         requireNonNull(mapper, "mapper can't be null");
 
         Option.Configuration config = Option.process(options);
@@ -127,7 +127,7 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
         }
     }
 
-    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<? super T, R> mapper, Executor executor, int parallelism) {
+    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<? super T, ? extends R> mapper, Executor executor, int parallelism) {
         return collectingAndThen(
           toList(),
           list -> {
@@ -155,11 +155,11 @@ class ParallelStreamCollector<T, R> implements Collector<T, List<CompletableFutu
           });
     }
 
-    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<? super T, R> mapper, int parallelism) {
+    static <T, R> Collector<T, ?, Stream<R>> batchingCollector(Function<? super T, ? extends R> mapper, int parallelism) {
         return batchingCollector(mapper, null, parallelism);
     }
 
-    static <T, R> Collector<T, Stream.Builder<R>, Stream<R>> syncCollector(Function<? super T, R> mapper) {
+    static <T, R> Collector<T, Stream.Builder<R>, Stream<R>> syncCollector(Function<? super T, ? extends R> mapper) {
         return Collector.of(Stream::builder, (rs, t) -> rs.add(mapper.apply(t)), (rs, rs2) -> {
             throw new UnsupportedOperationException("Using parallel stream with parallel collectors is a bad idea");
         }, Stream.Builder::build);

--- a/src/test/java/com/pivovarit/collectors/TypeBoundsTest.java
+++ b/src/test/java/com/pivovarit/collectors/TypeBoundsTest.java
@@ -5,78 +5,168 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import static java.util.stream.Collectors.toList;
 
 class TypeBoundsTest {
 
-    private final Function<Integer, String> its = i -> i.toString();
-    private final Function<Object, String> ots = i -> i.toString();
+    @Nested
+    class Covariance {
 
-    @Test
-    void shouldCompileBatchingParallel() {
-        Collector<Integer, ?, CompletableFuture<Stream<String>>> collector;
-        collector = ParallelCollectors.Batching.parallel(its, r -> {}, 42);
-        collector = ParallelCollectors.Batching.parallel(ots, r -> {}, 42);
+        private final Function<Integer, Number> itn = i -> i;
+        private final Function<Integer, Integer> iti = i -> i;
+
+        @Test
+        void shouldCompileBatchingParallel() {
+            Collector<Integer, ?, CompletableFuture<Stream<Number>>> collector;
+            collector = ParallelCollectors.Batching.parallel(itn, r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallel(iti, r -> {}, 42);
+        }
+
+        @Test
+        void shouldCompileBatchingParallelToList() {
+            Collector<Integer, ?, CompletableFuture<List<Number>>> collector;
+            collector = ParallelCollectors.Batching.parallel(itn, toList(), r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallel(iti, toList(), r -> {}, 42);
+        }
+
+        @Test
+        void shouldCompileBatchingStreaming() {
+            Collector<Integer, ?, Stream<Number>> collector;
+            collector = ParallelCollectors.Batching.parallelToStream(itn, r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallelToStream(iti, r -> {}, 42);
+
+            collector = ParallelCollectors.Batching.parallelToOrderedStream(itn, r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallelToOrderedStream(iti, r -> {}, 42);
+        }
+
+        @Test
+        void shouldCompileParallel() {
+            Collector<Integer, ?, CompletableFuture<Stream<Number>>> collector;
+            collector = ParallelCollectors.parallel(itn, r -> {}, 42);
+            collector = ParallelCollectors.parallel(iti, r -> {}, 42);
+
+            collector = ParallelCollectors.parallel(itn, r -> {});
+            collector = ParallelCollectors.parallel(iti, r -> {});
+
+            collector = ParallelCollectors.parallel(itn, 42);
+            collector = ParallelCollectors.parallel(iti, 42);
+
+            collector = ParallelCollectors.parallel(itn);
+            collector = ParallelCollectors.parallel(iti);
+        }
+
+        @Test
+        void shouldCompileParallelToList() {
+            Collector<Integer, ?, CompletableFuture<List<Number>>> collector;
+            collector = ParallelCollectors.parallel(itn, toList(), r -> {}, 42);
+            collector = ParallelCollectors.parallel(iti, toList(), r -> {}, 42);
+
+            collector = ParallelCollectors.parallel(itn, toList(), r -> {});
+            collector = ParallelCollectors.parallel(iti, toList(), r -> {});
+
+            collector = ParallelCollectors.parallel(itn, toList(), 42);
+            collector = ParallelCollectors.parallel(iti, toList(), 42);
+
+            collector = ParallelCollectors.parallel(itn, toList());
+            collector = ParallelCollectors.parallel(iti, toList());
+        }
+
+        @Test
+        void shouldCompileStreaming() {
+            Collector<Integer, ?, Stream<Number>> collector;
+            collector = ParallelCollectors.parallelToStream(itn, r -> {}, 42);
+            collector = ParallelCollectors.parallelToStream(iti, r -> {}, 42);
+
+            collector = ParallelCollectors.parallelToStream(itn, r -> {});
+            collector = ParallelCollectors.parallelToStream(iti, r -> {});
+
+            collector = ParallelCollectors.parallelToOrderedStream(itn, r -> {}, 42);
+            collector = ParallelCollectors.parallelToOrderedStream(iti, r -> {}, 42);
+
+            collector = ParallelCollectors.parallelToOrderedStream(itn, r -> {});
+            collector = ParallelCollectors.parallelToOrderedStream(iti, r -> {});
+        }
     }
 
-    @Test
-    void shouldCompileBatchingParallelToList() {
-        Collector<Integer, ?, CompletableFuture<List<String>>> collector;
-        collector = ParallelCollectors.Batching.parallel(its, toList(), r -> {}, 42);
-        collector = ParallelCollectors.Batching.parallel(ots, toList(), r -> {}, 42);
-    }
+    @Nested
+    class Contravariance {
 
-    @Test
-    void shouldCompileBatchingStreaming() {
-        Collector<Integer, ?, Stream<String>> collector;
-        collector = ParallelCollectors.Batching.parallelToStream(its, r -> {}, 42);
-        collector = ParallelCollectors.Batching.parallelToStream(ots, r -> {}, 42);
+        private final Function<Integer, String> its = i -> i.toString();
+        private final Function<Object, String> ots = i -> i.toString();
 
-        collector = ParallelCollectors.Batching.parallelToOrderedStream(its, r -> {}, 42);
-        collector = ParallelCollectors.Batching.parallelToOrderedStream(ots, r -> {}, 42);
-    }
+        @Test
+        void shouldCompileBatchingParallel() {
+            Collector<Integer, ?, CompletableFuture<Stream<String>>> collector;
+            collector = ParallelCollectors.Batching.parallel(its, r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallel(ots, r -> {}, 42);
+        }
 
-    @Test
-    void shouldCompileParallel() {
-        Collector<Integer, ?, CompletableFuture<Stream<String>>> collector;
-        collector = ParallelCollectors.parallel(its, r -> {}, 42);
-        collector = ParallelCollectors.parallel(ots, r -> {}, 42);
+        @Test
+        void shouldCompileBatchingParallelToList() {
+            Collector<Integer, ?, CompletableFuture<List<String>>> collector;
+            collector = ParallelCollectors.Batching.parallel(its, toList(), r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallel(ots, toList(), r -> {}, 42);
+        }
 
-        collector = ParallelCollectors.parallel(its, r -> {});
-        collector = ParallelCollectors.parallel(ots, r -> {});
+        @Test
+        void shouldCompileBatchingStreaming() {
+            Collector<Integer, ?, Stream<String>> collector;
+            collector = ParallelCollectors.Batching.parallelToStream(its, r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallelToStream(ots, r -> {}, 42);
 
-        collector = ParallelCollectors.parallel(its);
-        collector = ParallelCollectors.parallel(ots);
-    }
+            collector = ParallelCollectors.Batching.parallelToOrderedStream(its, r -> {}, 42);
+            collector = ParallelCollectors.Batching.parallelToOrderedStream(ots, r -> {}, 42);
+        }
 
-    @Test
-    void shouldCompileParallelToList() {
-        Collector<Integer, ?, CompletableFuture<List<String>>> collector;
-        collector = ParallelCollectors.parallel(its, toList(), r -> {}, 42);
-        collector = ParallelCollectors.parallel(ots, toList(), r -> {}, 42);
+        @Test
+        void shouldCompileParallel() {
+            Collector<Integer, ?, CompletableFuture<Stream<String>>> collector;
+            collector = ParallelCollectors.parallel(its, r -> {}, 42);
+            collector = ParallelCollectors.parallel(ots, r -> {}, 42);
 
-        collector = ParallelCollectors.parallel(its, toList(), r -> {});
-        collector = ParallelCollectors.parallel(ots, toList(), r -> {});
+            collector = ParallelCollectors.parallel(its, r -> {});
+            collector = ParallelCollectors.parallel(ots, r -> {});
 
-        collector = ParallelCollectors.parallel(its, toList());
-        collector = ParallelCollectors.parallel(ots, toList());
-    }
+            collector = ParallelCollectors.parallel(its, 42);
+            collector = ParallelCollectors.parallel(ots, 42);
 
-    @Test
-    void shouldCompileStreaming() {
-        Collector<Integer, ?, Stream<String>> collector;
-        collector = ParallelCollectors.parallelToStream(its, r -> {}, 42);
-        collector = ParallelCollectors.parallelToStream(ots, r -> {}, 42);
+            collector = ParallelCollectors.parallel(its);
+            collector = ParallelCollectors.parallel(ots);
+        }
 
-        collector = ParallelCollectors.parallelToStream(its, r -> {});
-        collector = ParallelCollectors.parallelToStream(ots, r -> {});
+        @Test
+        void shouldCompileParallelToList() {
+            Collector<Integer, ?, CompletableFuture<List<String>>> collector;
+            collector = ParallelCollectors.parallel(its, toList(), r -> {}, 42);
+            collector = ParallelCollectors.parallel(ots, toList(), r -> {}, 42);
 
-        collector = ParallelCollectors.parallelToOrderedStream(its, r -> {}, 42);
-        collector = ParallelCollectors.parallelToOrderedStream(ots, r -> {}, 42);
+            collector = ParallelCollectors.parallel(its, toList(), r -> {});
+            collector = ParallelCollectors.parallel(ots, toList(), r -> {});
 
-        collector = ParallelCollectors.parallelToOrderedStream(its, r -> {});
-        collector = ParallelCollectors.parallelToOrderedStream(ots, r -> {});
+            collector = ParallelCollectors.parallel(its, toList(), 42);
+            collector = ParallelCollectors.parallel(ots, toList(), 42);
+
+            collector = ParallelCollectors.parallel(its, toList());
+            collector = ParallelCollectors.parallel(ots, toList());
+        }
+
+        @Test
+        void shouldCompileStreaming() {
+            Collector<Integer, ?, Stream<String>> collector;
+            collector = ParallelCollectors.parallelToStream(its, r -> {}, 42);
+            collector = ParallelCollectors.parallelToStream(ots, r -> {}, 42);
+
+            collector = ParallelCollectors.parallelToStream(its, r -> {});
+            collector = ParallelCollectors.parallelToStream(ots, r -> {});
+
+            collector = ParallelCollectors.parallelToOrderedStream(its, r -> {}, 42);
+            collector = ParallelCollectors.parallelToOrderedStream(ots, r -> {}, 42);
+
+            collector = ParallelCollectors.parallelToOrderedStream(its, r -> {});
+            collector = ParallelCollectors.parallelToOrderedStream(ots, r -> {});
+        }
     }
 }


### PR DESCRIPTION
Let's say we have a `Collector` accepting `Integer` elements and returning a `Stream<Number>`.

This can be achieved by passing `Function<Integer, Number>`, but it would be perfectly valid to pass `Function<Integer, Integer>` as well, but it's not possible at the moment:

```java
Function<Integer, Number> f1 = i -> i;
Function<Integer, Integer> f2 = i -> i;

Collector<Integer, ?, CompletableFuture<Stream<Number>>> collector = ParallelCollectors.parallel(f1, 42);
// Incompatible equality constraint: Number and Integer
Collector<Integer, ?, CompletableFuture<Stream<Number>>> collector = ParallelCollectors.parallel(f2, 42);
```

This change loosens generic type bounds to maximize variance support, making this possible.

----

related: https://github.com/pivovarit/parallel-collectors/pull/1023
