### PR TITLE
Faster async Collector

### DIFF
--- a/src/test/resources/benchmarks/AsyncCollectorBenchmark.json
+++ b/src/test/resources/benchmarks/AsyncCollectorBenchmark.json
@@ -1,0 +1,114 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "com.pivovarit.collectors.AsyncCollectorBenchmark.existing",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Users/pivovarit/Library/Java/JavaVirtualMachines/openjdk-24/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-javaagent:/Users/pivovarit/Applications/IntelliJ IDEA Ultimate.app/Contents/lib/idea_rt.jar=53843",
+            "-Dfile.encoding=UTF-8",
+            "-Dsun.stdout.encoding=UTF-8",
+            "-Dsun.stderr.encoding=UTF-8"
+        ],
+        "jdkVersion" : "24",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "24+36-3646",
+        "warmupIterations" : 3,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 16990.05430982155,
+            "scoreError" : 277.9065128705215,
+            "scoreConfidence" : [
+                16712.147796951027,
+                17267.96082269207
+            ],
+            "scorePercentiles" : {
+                "0.0" : 16903.528950146898,
+                "50.0" : 17008.35112559356,
+                "90.0" : 17063.257603355265,
+                "95.0" : 17063.257603355265,
+                "99.0" : 17063.257603355265,
+                "99.9" : 17063.257603355265,
+                "99.99" : 17063.257603355265,
+                "99.999" : 17063.257603355265,
+                "99.9999" : 17063.257603355265,
+                "100.0" : 17063.257603355265
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    17063.257603355265,
+                    17008.35112559356,
+                    17049.382623809888,
+                    16925.751246202133,
+                    16903.528950146898
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "com.pivovarit.collectors.AsyncCollectorBenchmark.improved",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 1,
+        "jvm" : "/Users/pivovarit/Library/Java/JavaVirtualMachines/openjdk-24/Contents/Home/bin/java",
+        "jvmArgs" : [
+            "-javaagent:/Users/pivovarit/Applications/IntelliJ IDEA Ultimate.app/Contents/lib/idea_rt.jar=53843",
+            "-Dfile.encoding=UTF-8",
+            "-Dsun.stdout.encoding=UTF-8",
+            "-Dsun.stderr.encoding=UTF-8"
+        ],
+        "jdkVersion" : "24",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "24+36-3646",
+        "warmupIterations" : 3,
+        "warmupTime" : "10 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 5,
+        "measurementTime" : "10 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 32742.448513804447,
+            "scoreError" : 227.69772471404653,
+            "scoreConfidence" : [
+                32514.7507890904,
+                32970.14623851849
+            ],
+            "scorePercentiles" : {
+                "0.0" : 32685.457210248383,
+                "50.0" : 32710.42444519722,
+                "90.0" : 32826.72660640459,
+                "95.0" : 32826.72660640459,
+                "99.0" : 32826.72660640459,
+                "99.9" : 32826.72660640459,
+                "99.99" : 32826.72660640459,
+                "99.999" : 32826.72660640459,
+                "99.9999" : 32826.72660640459,
+                "100.0" : 32826.72660640459
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    32780.865621821395,
+                    32826.72660640459,
+                    32710.42444519722,
+                    32685.457210248383,
+                    32708.768685350646
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+


### PR DESCRIPTION
When a parallelism level of 1 is requested, it effectively means the Stream should be processed on a single thread. To do this efficiently, we've introduced a custom `Collector` implementation that avoids the overhead of task dispatching.

Further optimization was achieved by collecting elements directly into a `Stream.Builder`, which significantly improved performance:


```
Benchmark                         Mode     Cnt      Score       Error    Units
AsyncCollectorBenchmark.existing  thrpt    5        16990.054 ± 277.907  ops/s
AsyncCollectorBenchmark.improved  thrpt    5        32742.449 ± 227.698  ops/s
```

<img width="1304" alt="image" src="https://github.com/user-attachments/assets/e2ecfb02-d85e-4b38-8f30-ff2c657b33ab" />

----

```java
private static final List<Integer> source = IntStream.iterate(0, i -> i + 1)
  .limit(10_000)
  .boxed().toList();

    @Benchmark
    public Stream<Integer> existing() {
        return source.stream()
          .collect(AsyncParallelCollector.asyncCollector(i -> i, Executors.newVirtualThreadPerTaskExecutor(), i -> i))
          .join();
    }

    @Benchmark
    public Stream<Integer> improved() {
        return source.stream()
          .collect(AsyncParallelCollector.asyncCollectorNew(i -> i, Executors.newVirtualThreadPerTaskExecutor(), i -> i))
          .join();
    }
```
