### PR TITLE
Don't overshoot 'consumed' on last batch

### DIFF
--- a/src/main/java/com/pivovarit/collectors/BatchingSpliterator.java
+++ b/src/main/java/com/pivovarit/collectors/BatchingSpliterator.java
@@ -68,8 +68,9 @@ final class BatchingSpliterator<T> implements Spliterator<List<T>> {
     @Override
     public boolean tryAdvance(Consumer<? super List<T>> action) {
         if (consumed < source.size() && chunks != 0) {
-            List<T> batch = source.subList(consumed, Math.min(source.size(), consumed + chunkSize));
-            consumed += chunkSize;
+            int end = Math.min(source.size(), consumed + chunkSize);
+            List<T> batch = source.subList(consumed, end);
+            consumed += batch.size();
             chunkSize = (int) Math.ceil(((double) (source.size() - consumed)) / --chunks);
             action.accept(batch);
             return true;

--- a/src/test/java/com/pivovarit/collectors/BatchingSpliteratorTest.java
+++ b/src/test/java/com/pivovarit/collectors/BatchingSpliteratorTest.java
@@ -3,6 +3,7 @@ package com.pivovarit.collectors;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Spliterator;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -185,5 +186,21 @@ class BatchingSpliteratorTest {
         partitioned(input, 2).forEach(c -> {});
 
         assertThat(input).isEqualTo(List.of(1, 2, 3, 4, 5));
+    }
+
+    @Test
+    void shouldNotOvershootConsumedOnLastBatch() {
+        List<Integer> source = List.of(1, 2, 3, 4, 5);
+
+        Spliterator<List<Integer>> spliterator = new BatchingSpliterator<>(source, 2);
+
+        List<List<Integer>> result = new ArrayList<>();
+        while (spliterator.tryAdvance(result::add)) {
+            // no-op
+        }
+
+        assertThat(result).containsExactly(List.of(1, 2, 3), List.of(4, 5));
+
+        assertThat(result.stream().mapToInt(List::size).sum()).isEqualTo(source.size());
     }
 }


### PR DESCRIPTION
If the last batch had fewer than _chunkSize_ elements, _consumed_ would overshoot _source.size()_, which was incorrect but harmless.