### PR TITLE
Decrement 'remaining' only when element fetched

### DIFF
--- a/src/main/java/com/pivovarit/collectors/CompletionOrderSpliterator.java
+++ b/src/main/java/com/pivovarit/collectors/CompletionOrderSpliterator.java
@@ -30,9 +30,10 @@ final class CompletionOrderSpliterator<T> implements Spliterator<T> {
     }
 
     private CompletableFuture<T> nextCompleted() {
-        remaining--;
         try {
-            return completed.take();
+            var next = completed.take();
+            remaining--;
+            return next;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
 


### PR DESCRIPTION
Updated `CompletionOrderSpliterator` so the remaining counter is decremented only after a future is successfully retrieved, avoiding premature decrements on interruption