### PR TITLE
fix subtle testing concurrency bug

### DIFF
--- a/src/test/java/com/pivovarit/collectors/TestUtils.java
+++ b/src/test/java/com/pivovarit/collectors/TestUtils.java
@@ -1,7 +1,6 @@
 package com.pivovarit.collectors;
 
 import java.time.Duration;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -37,20 +36,10 @@ public final class TestUtils {
     }
 
     public synchronized static Integer incrementAndThrow(AtomicInteger counter) {
-        if (counter.incrementAndGet() >= 10) {
+        if (counter.get() >= 10) {
             throw new IllegalArgumentException();
         }
 
-        return counter.intValue();
-    }
-
-    public static void runWithExecutor(Consumer<Executor> consumer, int size) {
-        ExecutorService executor = Executors.newFixedThreadPool(size);
-
-        try {
-            consumer.accept(executor);
-        } finally {
-            executor.shutdown();
-        }
+        return counter.incrementAndGet();
     }
 }


### PR DESCRIPTION
Due to the increment happening first, once in a blue moon, we'd end up with a failing test
```
Error:  Failures: 
Error:    ExceptionHandlingTest.lambda$shouldShortcircuitOnException$1:48 
Expecting actual:
  100L
to be less than:
  100L 
```
