### PR TITLE
cancellation improvements

### DIFF
--- a/src/main/java/com/pivovarit/collectors/AsyncCollector.java
+++ b/src/main/java/com/pivovarit/collectors/AsyncCollector.java
@@ -18,7 +18,6 @@ package com.pivovarit.collectors;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
-import java.util.concurrent.FutureTask;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -49,49 +48,16 @@ record AsyncCollector<T, R, RR>(Function<? super T, ? extends R> mapper, Functio
     @Override
     public Function<Stream.Builder<T>, CompletableFuture<RR>> finisher() {
         return acc -> {
-            var result = new InterruptibleCompletableFuture<RR>();
-            var task = new FutureTask<>(() -> {
-                try {
-                    var mapped = acc.build().map(mapper).map(e -> (R) e).toList();
-                    result.complete(processor.apply(mapped.stream()));
-                } catch (Throwable e) {
-                    result.completeExceptionally(e);
-                }
-            }, null);
-            result.completedBy(task);
-            result.whenComplete((__, ex) -> {
-                if (ex != null) {
-                    task.cancel(true);
-                }
-            });
             try {
-                executor.execute(task);
+                return CompletableFuture.supplyAsync(() -> processor.apply(acc.build().map(mapper)), executor);
             } catch (Exception e) {
-                result.completeExceptionally(e);
+                return CompletableFuture.failedFuture(e);
             }
-            return result;
         };
     }
 
     @Override
     public Set<Characteristics> characteristics() {
         return Set.of();
-    }
-
-    private static final class InterruptibleCompletableFuture<T> extends CompletableFuture<T> {
-
-        private volatile FutureTask<?> backingTask;
-
-        private void completedBy(FutureTask<?> task) {
-            backingTask = task;
-        }
-
-        @Override
-        public boolean cancel(boolean mayInterruptIfRunning) {
-            if (backingTask != null) {
-                backingTask.cancel(mayInterruptIfRunning);
-            }
-            return super.cancel(mayInterruptIfRunning);
-        }
     }
 }

--- a/src/main/java/com/pivovarit/collectors/AsyncCollector.java
+++ b/src/main/java/com/pivovarit/collectors/AsyncCollector.java
@@ -18,6 +18,7 @@ package com.pivovarit.collectors;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
 import java.util.function.BiConsumer;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
@@ -48,16 +49,49 @@ record AsyncCollector<T, R, RR>(Function<? super T, ? extends R> mapper, Functio
     @Override
     public Function<Stream.Builder<T>, CompletableFuture<RR>> finisher() {
         return acc -> {
+            var result = new InterruptibleCompletableFuture<RR>();
+            var task = new FutureTask<>(() -> {
+                try {
+                    var mapped = acc.build().map(mapper).map(e -> (R) e).toList();
+                    result.complete(processor.apply(mapped.stream()));
+                } catch (Throwable e) {
+                    result.completeExceptionally(e);
+                }
+            }, null);
+            result.completedBy(task);
+            result.whenComplete((__, ex) -> {
+                if (ex != null) {
+                    task.cancel(true);
+                }
+            });
             try {
-                return CompletableFuture.supplyAsync(() -> processor.apply(acc.build().map(mapper)), executor);
+                executor.execute(task);
             } catch (Exception e) {
-                return CompletableFuture.failedFuture(e);
+                result.completeExceptionally(e);
             }
+            return result;
         };
     }
 
     @Override
     public Set<Characteristics> characteristics() {
         return Set.of();
+    }
+
+    private static final class InterruptibleCompletableFuture<T> extends CompletableFuture<T> {
+
+        private volatile FutureTask<?> backingTask;
+
+        private void completedBy(FutureTask<?> task) {
+            backingTask = task;
+        }
+
+        @Override
+        public boolean cancel(boolean mayInterruptIfRunning) {
+            if (backingTask != null) {
+                backingTask.cancel(mayInterruptIfRunning);
+            }
+            return super.cancel(mayInterruptIfRunning);
+        }
     }
 }

--- a/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
+++ b/src/main/java/com/pivovarit/collectors/AsyncParallelCollector.java
@@ -58,7 +58,15 @@ final class AsyncParallelCollector<T, R, C> extends AbstractParallelCollector<T,
                 });
             }
 
-            return combined.thenApply(finalizer);
+            var result = combined.thenApply(finalizer);
+            result.whenComplete((__, ex) -> {
+                if (ex != null) {
+                    for (var future : futures) {
+                        future.cancel(true);
+                    }
+                }
+            });
+            return result;
         };
     }
 

--- a/src/test/java/com/pivovarit/collectors/test/CancellationTest.java
+++ b/src/test/java/com/pivovarit/collectors/test/CancellationTest.java
@@ -16,7 +16,6 @@
 package com.pivovarit.collectors.test;
 
 import com.pivovarit.collectors.ParallelCollectors;
-
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -96,19 +95,15 @@ class CancellationTest {
           collector("parallel() [executor]", 8, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e))),
           collector("parallel() [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4))),
           collector("parallel() [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4).batching())),
-          collector("parallel() [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(1))),
           collector("parallel(toList()) [executor]", 8, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e), toList())),
           collector("parallel(toList()) [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4), toList())),
           collector("parallel(toList()) [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4).batching(), toList())),
-          collector("parallel(toList()) [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(1), toList())),
           collector("parallelBy() [executor]", 8, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e))),
           collector("parallelBy() [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4))),
           collector("parallelBy() [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4).batching())),
-          collector("parallelBy() [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(1))),
           collector("parallelBy(toList()) [executor]", 8, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e), toList())),
           collector("parallelBy(toList()) [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4), toList())),
-          collector("parallelBy(toList()) [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4).batching(), toList())),
-          collector("parallelBy(toList()) [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(1), toList()))
+          collector("parallelBy(toList()) [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4).batching(), toList()))
         );
     }
 

--- a/src/test/java/com/pivovarit/collectors/test/CancellationTest.java
+++ b/src/test/java/com/pivovarit/collectors/test/CancellationTest.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2014-2026 Grzegorz Piwowarek, https://4comprehension.com/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pivovarit.collectors.test;
+
+import com.pivovarit.collectors.ParallelCollectors;
+
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collector;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.DynamicTest.dynamicTest;
+
+class CancellationTest {
+
+    @TestFactory
+    Stream<DynamicTest> shouldInterruptRunningTasksOnCancellation() {
+        return allCancellableCollectors()
+          .map(c -> dynamicTest(c.name(), () -> {
+              var executor = Executors.newVirtualThreadPerTaskExecutor();
+              try {
+                  var started = new CountDownLatch(c.minimumInterruptions());
+                  var interrupted = new AtomicInteger();
+
+                  var result = IntStream.range(0, c.taskCount())
+                    .boxed()
+                    .collect(c.factory().collector(i -> sleepUntilInterrupted(started, interrupted, i), executor));
+
+                  assertThat(started.await(1, SECONDS)).isTrue();
+                  assertThat(result.cancel(true)).isTrue();
+
+                  await().atMost(5, SECONDS).untilAsserted(() -> assertThat(interrupted.get()).isGreaterThanOrEqualTo(c.minimumInterruptions()));
+              } finally {
+                  executor.shutdownNow();
+              }
+          }));
+    }
+
+    @TestFactory
+    Stream<DynamicTest> shouldInterruptRunningTasksOnTimeout() {
+        return allCancellableCollectors()
+          .map(c -> dynamicTest(c.name(), () -> {
+              var executor = Executors.newVirtualThreadPerTaskExecutor();
+              try {
+                  var started = new CountDownLatch(c.minimumInterruptions());
+                  var interrupted = new AtomicInteger();
+
+                  var result = IntStream.range(0, c.taskCount())
+                    .boxed()
+                    .collect(c.factory().collector(i -> sleepUntilInterrupted(started, interrupted, i), executor));
+
+                  assertThat(started.await(1, SECONDS)).isTrue();
+                  result.orTimeout(10, MILLISECONDS);
+
+                  assertThatThrownBy(result::join)
+                    .isInstanceOf(CompletionException.class)
+                    .hasCauseExactlyInstanceOf(TimeoutException.class);
+                  await().atMost(5, SECONDS).untilAsserted(() -> assertThat(interrupted.get()).isGreaterThanOrEqualTo(c.minimumInterruptions()));
+              } finally {
+                  executor.shutdownNow();
+              }
+          }));
+    }
+
+    private static Stream<CancellableCollector> allCancellableCollectors() {
+        return Stream.of(
+          collector("parallel() [executor]", 8, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e))),
+          collector("parallel() [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4))),
+          collector("parallel() [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4).batching())),
+          collector("parallel() [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(1))),
+          collector("parallel(toList()) [executor]", 8, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e), toList())),
+          collector("parallel(toList()) [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4), toList())),
+          collector("parallel(toList()) [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(4).batching(), toList())),
+          collector("parallel(toList()) [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallel(f, c -> c.executor(e).parallelism(1), toList())),
+          collector("parallelBy() [executor]", 8, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e))),
+          collector("parallelBy() [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4))),
+          collector("parallelBy() [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4).batching())),
+          collector("parallelBy() [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(1))),
+          collector("parallelBy(toList()) [executor]", 8, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e), toList())),
+          collector("parallelBy(toList()) [executor, parallelism]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4), toList())),
+          collector("parallelBy(toList()) [executor, parallelism, batching]", 4, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(4).batching(), toList())),
+          collector("parallelBy(toList()) [executor, parallelism=1]", 1, (f, e) -> ParallelCollectors.parallelBy(i -> i, f, c -> c.executor(e).parallelism(1), toList()))
+        );
+    }
+
+    private static CancellableCollector collector(String name, int minimumInterruptions, CancellableCollectorFactory factory) {
+        return new CancellableCollector(name, 8, minimumInterruptions, factory);
+    }
+
+    private static int sleepUntilInterrupted(CountDownLatch started, AtomicInteger interrupted, int value) {
+        started.countDown();
+        try {
+            Thread.sleep(Duration.ofDays(1));
+        } catch (InterruptedException e) {
+            interrupted.incrementAndGet();
+            Thread.currentThread().interrupt();
+        }
+        return value;
+    }
+
+    private record CancellableCollector(String name, int taskCount, int minimumInterruptions, CancellableCollectorFactory factory) {
+    }
+
+    @FunctionalInterface
+    private interface CancellableCollectorFactory {
+        Collector<Integer, ?, ? extends CompletableFuture<?>> collector(Function<Integer, Integer> mapper, Executor executor);
+    }
+}


### PR DESCRIPTION
external completion of the returned CompletableFuture did not reliably propagate to active work. That meant patterns like:

```stream.collect(parallel(mapper, toList())).orTimeout(1, SECONDS)```

could complete the public future with a timeout while mapper tasks continued running in the executor.