### PR TITLE
Update CI workflow to include Java 27-ea

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        java: [ '21', '22', '23', '24', '25', '26' ]
+        java: [ '21', '22', '23', '24', '25', '26', '27-ea' ]
         architecture: [ 'x64' ]
     name: Build with JDK ${{ matrix.java }} on ${{ matrix.architecture }}
     steps:


### PR DESCRIPTION
Added Java version '27-ea' to the CI workflow matrix.